### PR TITLE
Change withFiles method to return the Trix parent

### DIFF
--- a/src/CKEditor5Classic.php
+++ b/src/CKEditor5Classic.php
@@ -28,15 +28,7 @@ class CKEditor5Classic extends Trix
      */
     public function withFiles($disk = null)
     {
-        $this->withFiles = true;
-
-        $this->disk($disk);
-
-        $this->attach(new StorePendingAttachment($this))
-            ->discard(new DiscardPendingAttachments())
-            ->prunable();
-
-        return $this;
+        return parent::withFiles($disk);
     }
 
     /**


### PR DESCRIPTION
Return the Trix withFiles method to prevent "call_user_func() expects parameter 1 to be a valid callback, no array or string given" error in softDelete Models.