### PR TITLE
Fix docblock of withFiles method

### DIFF
--- a/src/CKEditor5Classic.php
+++ b/src/CKEditor5Classic.php
@@ -39,7 +39,7 @@ class CKEditor5Classic extends Trix
         ]);
     }
     /**
-     * @param null $disk
+     * @param string|null $disk
      * @return $this
      */
     public function withFiles($disk = null)


### PR DESCRIPTION
Docblock of withFiles misses the string type, which makes tools like PHPStorm and PHPStan complain.