### PR TITLE
Create link with target _blank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,14 +3,14 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@ckeditor/ckeditor5-build-classic": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-12.2.0.tgz",
-            "integrity": "sha512-En64jC5ImZoa+XLa2JrZYCKpq2iNXhdf17xgmpJoAXp+m36EqSHd6/4x0XT/pjrZSDxrcLUZxyZJlQCRtSaeHw=="
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-12.4.0.tgz",
+            "integrity": "sha512-KzndcFz45e96z/ErToABYFf7mtcHyPCyNzzobAkpBRzKqBoS0CMDmLjHWWnL0ite39oidgBJ7PXt+iRl7p+5jA=="
         },
         "@ckeditor/ckeditor5-vue": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.0-beta.2.tgz",
-            "integrity": "sha512-9qF795EKQZi2VV5zgYjUfAY2L3rr50NaZOAMq2O2sADrWMxUGOb3cUAD6FuV3kboVaKoSmXGcApm7Iy5YTGr3g=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.0.tgz",
+            "integrity": "sha512-rrwuRQ/vHPnBDBhgOj/0y0QlJTmTJwPWF9QbyxJ/ThPFE8U8823HGZ6wKOCtXOzuNmGvFkXRKQULpXupo4URRw=="
         },
         "@types/q": {
             "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "laravel-nova": "^1.0"
     },
     "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^12.1.0",
-        "@ckeditor/ckeditor5-vue": "^1.0.0-beta.2",
+        "@ckeditor/ckeditor5-build-classic": "^12.4.0",
+        "@ckeditor/ckeditor5-vue": "^1.0.0",
         "vue": "^2.5.0"
     }
 }

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -47,7 +47,8 @@ export default {
                 fontFamily: this.field.options.fontFamily,
                 extraPlugins: [
                     this.createUploadAdapterPlugin
-                ]
+                ],
+                link: this.field.options.link
             }
         }
     },


### PR DESCRIPTION
I updated CKEditor to be able to add target attribute to link.

Exemple of configuration :

```php
return [
    'options' => [
        'language' => 'en',
        'plugins' => ['Link'],
        'toolbar' => [
            'Heading',
            'Bold',
            'Italic',
            '-',
            'Link',
        ],
        'link' => [
          'addTargetToExternalLinks' => true,
          'decorators' => [
            'isExternal' => [
                'mode' => 'manual',
                'label' => 'Open in a new tab ?',
                'attributes' => [
                    'target' => '_blank',
                    'rel'=> 'noopener noreferrer'
                ]
            ],
          ]
        ],
    ]
];
```