### PR TITLE
Adds configuration for Attachments models

### DIFF
--- a/config/ckeditor5Classic.php
+++ b/config/ckeditor5Classic.php
@@ -3,6 +3,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------------
+    | CKEditor Model
+    |--------------------------------------------------------------------------------
+    |
+    | The fully qualified class name of models.
+    |
+    */
+
+    'attachment_model' => \NumaxLab\NovaCKEditor5Classic\Models\Attachment::class,
+    'pending_attachment_model' => \NumaxLab\NovaCKEditor5Classic\Models\PendingAttachment::class,
+
+    /*
+    |--------------------------------------------------------------------------------
     | CKEditor Options
     |--------------------------------------------------------------------------------
     |

--- a/src/CKEditor5Classic.php
+++ b/src/CKEditor5Classic.php
@@ -74,7 +74,7 @@ class CKEditor5Classic extends Trix
 
         if ($request->{$this->attribute.'DraftId'} && $this->withFiles) {
             return function () use ($request, $model, $attribute) {
-                PendingAttachment::persistDraft(
+                config('ckeditor5Classic.pending_attachment_model')::persistDraft(
                     $request->{$this->attribute.'DraftId'},
                     $this,
                     $model

--- a/src/Handlers/DiscardPendingAttachments.php
+++ b/src/Handlers/DiscardPendingAttachments.php
@@ -15,7 +15,7 @@ class DiscardPendingAttachments
      */
     public function __invoke(Request $request)
     {
-        PendingAttachment::where('draft_id', $request->draftId)
+        config('ckeditor5Classic.pending_attachment_model')::where('draft_id', $request->draftId)
             ->get()
             ->each
             ->purge();

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -43,7 +43,7 @@ class StorePendingAttachment
 
         $this->abortIfFileNameExists($filename);
 
-        $attachment = PendingAttachment::create([
+        $attachment = config('ckeditor5Classic.pending_attachment_model')::create([
             'draft_id' => $request->draftId,
             'attachment' => $request->attachment->storeAs(
                 self::STORAGE_PATH,

--- a/src/Jobs/PruneStaleAttachments.php
+++ b/src/Jobs/PruneStaleAttachments.php
@@ -13,7 +13,7 @@ class PruneStaleAttachments
      */
     public function __invoke()
     {
-        PendingAttachment::where('created_at', '<=', now()->subDays(1))
+        config('ckeditor5Classic.pending_attachment_model')::where('created_at', '<=', now()->subDays(1))
             ->orderBy('id', 'desc')
             ->chunk(100, function ($attachments) {
                 $attachments->each->purge();

--- a/src/Models/DeleteAttachments.php
+++ b/src/Models/DeleteAttachments.php
@@ -33,7 +33,7 @@ class DeleteAttachments
      */
     public function __invoke(Request $request, $model)
     {
-        Attachment::where('attachable_type', get_class($model))
+        config('ckeditor5Classic.attachment_model')::where('attachable_type', get_class($model))
                 ->where('attachable_id', $model->getKey())
                 ->get()
                 ->each

--- a/src/Models/DetachAttachment.php
+++ b/src/Models/DetachAttachment.php
@@ -14,7 +14,7 @@ class DetachAttachment
      */
     public function __invoke(Request $request)
     {
-        Attachment::where('url', $request->attachmentUrl)
+        config('ckeditor5Classic.attachment_model')::where('url', $request->attachmentUrl)
                         ->get()
                         ->each
                         ->purge();

--- a/src/Models/PendingAttachment.php
+++ b/src/Models/PendingAttachment.php
@@ -46,7 +46,7 @@ class PendingAttachment extends Model
      */
     public function persist(CKEditor5Classic $field, $model)
     {
-        Attachment::create([
+        config('ckeditor5Classic.attachment_model')::create([
             'attachable_type' => get_class($model),
             'attachable_id' => $model->getKey(),
             'attachment' => $this->attachment,


### PR DESCRIPTION
In some cases, we can want to override the Attachments classes. By making them configurable, the developer has more flexibility.

Personally, it's because I'm using multi-tenancy and so I have to provide a specific database name each time a model interacts with the database.