### PR TITLE
Make storage path configurable

### DIFF
--- a/src/CKEditor5Classic.php
+++ b/src/CKEditor5Classic.php
@@ -19,6 +19,13 @@ class CKEditor5Classic extends Trix
      */
     public $component = 'ckeditor5-classic-field';
 
+    /**
+     * The file storage path.
+     *
+     * @var string
+     */
+    public $storagePath = '/attachments';
+
     public function __construct(string $name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);

--- a/src/Handlers/StorePendingAttachment.php
+++ b/src/Handlers/StorePendingAttachment.php
@@ -12,8 +12,6 @@ use NumaxLab\NovaCKEditor5Classic\Models\PendingAttachment;
 
 class StorePendingAttachment
 {
-    public const STORAGE_PATH = '/attachments';
-
     /**
      * The field instance.
      *
@@ -46,7 +44,7 @@ class StorePendingAttachment
         $attachment = config('ckeditor5Classic.pending_attachment_model')::create([
             'draft_id' => $request->draftId,
             'attachment' => $request->attachment->storeAs(
-                self::STORAGE_PATH,
+                $this->field->storagePath,
                 $filename,
                 $this->field->disk
             ),
@@ -61,7 +59,7 @@ class StorePendingAttachment
      */
     protected function abortIfFileNameExists($filename): void
     {
-        if (Storage::disk($this->field->disk)->exists(self::STORAGE_PATH.'/'.$filename)) {
+        if (Storage::disk($this->field->disk)->exists(rtrim($this->field->storagePath, '/').'/'.$filename)) {
             abort(response()->json([
                 'status' => Response::HTTP_CONFLICT,
                 'message' => 'A file with this name already exists on the server'


### PR DESCRIPTION
## Description

I've made the storage path configurable. The default is still `/attachments` for backwards compatibility.

## Motivation and context

Currently all files are stored in the attachments directory, but our project requires another directory structure. You can set the path on the field, just like the Trix field, but currently it is ignored.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)